### PR TITLE
Fix filter error in get_loopbacks.py

### DIFF
--- a/yang/get_loopbacks.py
+++ b/yang/get_loopbacks.py
@@ -29,7 +29,7 @@ def main():
                 <lb-items></lb-items>
             </intf-items>
         </System>
-    </config>"""
+    </filter>"""
 
     ipv4_filter_template = """
     <filter>
@@ -49,7 +49,7 @@ def main():
                 </inst-items>
             </ipv4-items>
         </System>
-    </config>"""
+    </filter>"""
 
 
 


### PR DESCRIPTION
The filters closing tag should be `</filter>` as defined in the [RFC 6241 section 6.2.2](https://tools.ietf.org/html/rfc6241#section-6.2.2).

When the closing that is `</config>` you get the following error:
```python
lxml.etree.XMLSyntaxError: Opening and ending tag mismatch: filter line 2 and config, line 8, column 14
```